### PR TITLE
rename keys would be used while creating

### DIFF
--- a/src/controllers/doctorController.js
+++ b/src/controllers/doctorController.js
@@ -1,5 +1,6 @@
 const DoctorServices = require("../services/doctorServices");
 const { messageUtil } = require("../utilities/message");
+const { renameKey } = require("../utilities/replaceKey");
 const {
   successResponse,
   serverErrorResponse,
@@ -14,7 +15,6 @@ const CreateDoctor = async (req, res) => {
     if (!dateRegex.test(req.body.birthdate)) {
       return badRequestErrorResponse(res, "Invalid date format");
     }
-
     const document = await DoctorServices.createDoctor({
       ...req.body,
     });
@@ -110,7 +110,7 @@ const AllDoctors = async (req, res) => {
     const documents = await DoctorServices.getDoctors(query, limitQP, skipOP);
     return successResponse(res, messageUtil.success, {
       objectCount: documents.objectsCount,
-      objectArray: documents.updatedDocument,
+      objectArray: documents.object,
     });
   } catch (error) {
     return serverErrorResponse(res, error);

--- a/src/schemas/doctorSchema.js
+++ b/src/schemas/doctorSchema.js
@@ -16,7 +16,7 @@ const doctorSchema = new mongoose.Schema(
       type: String,
       required: [true, `please enter valid last name`],
     },
-    specialtyId: {
+    specialty: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "medicalSpecialties",
       required: [true, `please provide valid specialty id`],
@@ -41,8 +41,8 @@ const doctorSchema = new mongoose.Schema(
   { collection: "doctors" }
 );
 
-doctorSchema.pre(['find' , 'findOne' , 'save'], function(next) {
-  this.populate('specialtyId' , '-__v -_id -id');
+doctorSchema.pre(['find' , 'findOne' , 'save' , 'findOneAndUpdate'], function(next) {
+  this.populate('specialty' , '-__v -_id -id');
   next();
 });
 

--- a/src/schemas/institutionSchema.js
+++ b/src/schemas/institutionSchema.js
@@ -10,7 +10,7 @@ const institutionSchema = new mongoose.Schema(
       type: String,
       required: [true, "please provide Phone Number"],
     },
-    cityId: {
+    city: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "cities",
       required: [true, "please provide cityid"],
@@ -103,9 +103,8 @@ const institutionSchema = new mongoose.Schema(
   { timestamps: true },
 );
 
-institutionSchema.pre(["find", "findOne"], function (next) {
-  this.populate("cityId", "-_id -__v");
-  this.lean();
+institutionSchema.pre(["find", "findOne" , "save" , "findOneAndUpdate"], function (next) {
+  this.populate("city", "-_id -__v");
   next();
 });
 

--- a/src/schemas/medicalCenterSchema.js
+++ b/src/schemas/medicalCenterSchema.js
@@ -8,7 +8,7 @@ const medicalCenterSchema = new mongoose.Schema(
       type: String,
       required: [true, `please enter valid  name`],
     },
-    cityId: {
+    city: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "cities",
       required: [true, `please enter valid city ID`],
@@ -53,8 +53,8 @@ const medicalCenterSchema = new mongoose.Schema(
 
 
 // this middleware will always return the city object and not the city objectId
-medicalCenterSchema.pre(['find' , "findOne"], function(next) {
-  this.populate('cityId' , '-_id -__v');
+medicalCenterSchema.pre(['find' , "findOne" , "save" , "findOneAndUpdate"], function(next) {
+  this.populate('city' , '-_id -__v');
   next();
 });
 

--- a/src/schemas/pharmacySchema.js
+++ b/src/schemas/pharmacySchema.js
@@ -7,7 +7,7 @@ const pharmacySchema = new mongoose.Schema(
       type: String,
       required: [true, `please enter valid  name`],
     },
-    cityId: {
+    city: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "cities",
       required: [true, `please enter valid city`],
@@ -47,8 +47,8 @@ const pharmacySchema = new mongoose.Schema(
   { timestamps: true }
 );
 // this middleware will always return the city object and not the city objectId
-pharmacySchema.pre(['find' , "findOne"], function(next) {
-  this.populate('cityId' , '-_id -__v');
+pharmacySchema.pre(['find' , "findOne" , "save" , "findOneAndUpdate"], function(next) {
+  this.populate('city' , '-_id -__v');
   next();
 });
 const pharmacy = mongoose.model(`pharmacy`, pharmacySchema);

--- a/src/schemas/scheduleSchema.js
+++ b/src/schemas/scheduleSchema.js
@@ -2,19 +2,18 @@ const mongoose = require(`mongoose`);
 
 const scheduleSchema = new mongoose.Schema(
   {
-    medicalCenterId: {
+    medicalCenter: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "medicalCenters",
       required: [true, `please provide valid medicalCenter id`],
     },
-    doctorId: {
+    doctor: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "doctors",
       required: [true, `please provide valid doctor id`],
     },
-    timeSlotId: {
+    timeSlot: {
       type: mongoose.Schema.Types.ObjectId,
-      set: (v) => mongoose.Types.ObjectId(v),
       ref: "timeSlotEnum",
       required: [true, `please provide valid timeslot`],
     },
@@ -61,12 +60,11 @@ const scheduleSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-scheduleSchema.pre(['find' , 'findOne' , 'save' , 'create'], function(next) {
-  this.populate('medicalCenterId' , '-__v -_id -id');
-  this.populate('doctorId' , '-__v -_id -id');
+
+scheduleSchema.pre(['find' , 'findOne' , 'save' , 'create' , 'findOneAndUpdate'], function(next) {
+  this.populate('timeSlot' , '-__v -_id -id');
   next();
 });
-
 
 
 const schedule = mongoose.model(`schedules`, scheduleSchema);

--- a/src/services/doctorServices.js
+++ b/src/services/doctorServices.js
@@ -1,18 +1,14 @@
 const DoctorSchema = require("../schemas/doctorSchema");
-const uploader = require("../utilities/uploader");
+const { renameKey } = require("../utilities/replaceKey");
 exports.createDoctor = async (query) => {
-  const createDoctor = await DoctorSchema.create(query);
-  // const leanObject = await this.getDoctorDetails({_id : createDoctor._id});
-  const leanObject = createDoctor.toObject({ getters: true });
-  // console.log("before renaming" , leanObject);
-  const renamedData = uploader.renameKey(leanObject , "specialty" , "specialtyId");
-  // console.log("after renaming" , renamedData)
-  return renamedData;
-  
+  const renamedData = renameKey(query , "specialty" , "specialtyId");
+  const createDoctor = await DoctorSchema.create(renamedData);
+  return createDoctor;
 };
 
 exports.updateDoctor = async (query, data) => {
-  return await DoctorSchema.findOneAndUpdate(query, data, {
+  const renamedData = renameKey(data , "specialty" , "specialtyId");
+  return await DoctorSchema.findOneAndUpdate(query, renamedData, {
     new: true,
   }).select("-__v -createdAt -updatedAt");
 };
@@ -31,13 +27,10 @@ exports.getDoctors = async (query, limit, skip , sort) => {
     .limit(limit)
     .select("-__v")
     .lean();
-  const updatedDocument = object.map(doctorObject =>  uploader.renameKey(doctorObject ,"specialty", "specialtyId"));
-  return {updatedDocument, objectsCount};
+  return {object, objectsCount};
 };
 
 exports.getDoctorDetails = async (query) => {
-
   const returnedDoc =  await DoctorSchema.findOne(query).select("-__v -createdAt -updatedAt").lean();
-  const renamedData = uploader.renameKey(returnedDoc , "specialty" , "specialtyId");
-  return renamedData;
+  return returnedDoc;
 };

--- a/src/services/institutionServices.js
+++ b/src/services/institutionServices.js
@@ -1,16 +1,17 @@
 const config = require("../config/config");
 const InstitutionSchema = require("../schemas/institutionSchema");
+const { renameKey } = require("../utilities/replaceKey");
 const uploader = require("../utilities/uploader");
 exports.createInstitution = async (query) => {
-  const document = await InstitutionSchema.create(query);
+  const renamedData = renameKey(query , "city" , "cityId");
+  const document = await InstitutionSchema.create(renamedData);
   const doc = await uploader.returnedSingleDoc(InstitutionSchema , document._id);
   return doc;
 };
 
 exports.updateInstitution = async (query, data) => {
-  const updatedDocument =  await InstitutionSchema.findOneAndUpdate(query, data, {
-    new: true,
-  });
+  const renamedData = renameKey(data , "city" , "cityId");
+  const updatedDocument =  await InstitutionSchema.findOneAndUpdate(query, renamedData, {new: true});
   if(updatedDocument?.fileLink.length) {
     const presignedUrlArray = await Promise.all(updatedDocument.fileLink.map(async link => await uploader.getPresignedUrl(link , config.dalilStorage_bucket)));
     updatedDocument.fileLink = presignedUrlArray;
@@ -38,8 +39,7 @@ exports.getAllInstitution = async (query , limit, skip , sort) => {
       const presignedUrlArray = await Promise.all(data.fileLink.map(async link => await uploader.getPresignedUrl(link , config.dalilStorage_bucket)));
       data.fileLink = presignedUrlArray;
     }
-    const renamedData = uploader.renameKey(data , "city" , "cityId");
-    return renamedData; 
+    return data; 
   }))
 
   return {objectsCount , newDocuments};

--- a/src/services/pharmacyServices.js
+++ b/src/services/pharmacyServices.js
@@ -2,14 +2,17 @@ const config = require("../config/config");
 const PharmacySchema = require("../schemas/pharmacySchema");
 const _ = require("lodash");
 const uploader = require("../utilities/uploader");
+const { renameKey } = require("../utilities/replaceKey");
 exports.createPharmacy = async (query) => {
-  const createdDoc = await PharmacySchema.create(query);
+  const renamedData = renameKey(query , "city" , "cityId");
+  const createdDoc = await PharmacySchema.create(renamedData);
   const doc = await uploader.returnedSingleDoc(PharmacySchema , createdDoc._id);
   return doc;
 };
 
 exports.updatePharmacy = async (query, data) => {
-  return await PharmacySchema.findOneAndUpdate(query, data, {
+  const renamedData = renameKey(data , "city" , "cityId");
+  return await PharmacySchema.findOneAndUpdate(query, renamedData, {
     new: true,
   });
 };
@@ -32,15 +35,12 @@ exports.getAllPharmacys = async (query, limit, skip) => {
       const presignedUrlArray = await Promise.all(data.fileLink.map(async link => await uploader.getPresignedUrl(link , config.dalilStorage_bucket)));
       data.fileLink = presignedUrlArray;
     }
-    const renamedData = uploader.renameKey(data , "city" , "cityId");
-    return renamedData;
+    return data;
   }))
-
   return {objectsCount, newDocuments};
 };
 
 exports.getPharmacyDetails = async (query) => {
-    console.log(query)
   const pharmacyDoc = await uploader.returnedSingleDoc(PharmacySchema , query);
   return pharmacyDoc;
 };

--- a/src/utilities/replaceKey.js
+++ b/src/utilities/replaceKey.js
@@ -1,14 +1,69 @@
 function replaceKey(object, newKey, oldKey) {
   // check if the document has the old key
-  if (!object.hasOwnProperty(oldKey)) {
-    return object; // return the original document if oldKey is not found
+  // if (!object.hasOwnProperty(oldKey)) {
+  //   return object; // return the original document if oldKey is not found
+  // }
+
+  // const newKey = 'newKey';
+  // oldObj[newKey] = oldObj[oldKey]
+  // delete oldObj[oldKey];
+
+  // return newDocument;
+}
+
+function renameKey(document, newKeys, oldKeys) {
+  // check if newKeys and oldKeys are strings and convert them to arrays if necessary
+  if (typeof newKeys === "string" && typeof oldKeys === "string") {
+    newKeys = [newKeys];
+    oldKeys = [oldKeys];
   }
 
-  const newKey = 'newKey';
-  oldObj[newKey] = oldObj[oldKey]
-  delete oldObj[oldKey];
+  // if newKeys or oldKeys are not arrays or have different lengths, return the original document
+  if (!Array.isArray(newKeys) || !Array.isArray(oldKeys) || newKeys.length !== oldKeys.length) {
+    return document;
+  }
+
+  // create a new object to hold the renamed keys
+  const newDocument = {};
+
+  // loop through the keys in the original document
+  for (const [key, value] of Object.entries(document)) {
+    // check if the current key matches any oldKey
+    const index = oldKeys.indexOf(key);
+    if (index !== -1) {
+      // use the corresponding newKey instead
+      newDocument[newKeys[index]] = value;
+    } else {
+      // use the original key
+      newDocument[key] = value;
+    }
+  }
+
+  // also rename any key that matches an oldKey in subdocuments recursively
+  for (const [key, value] of Object.entries(newDocument)) {
+    if (typeof value === "object" && value !== null) {
+      newDocument[key] = renameKey(value, newKeys, oldKeys);
+    }
+  }
 
   return newDocument;
 }
 
-module.exports = { replaceKey };
+
+
+// a new utility function , it can be used to remove the keys from document, multiple or single
+function removeKey (document , removeArg) {
+  if(Array.isArray(removeArg)) {
+    for (let i = 0 ; i <= removeArg.length - 1 ; i++) {
+      deleteKey(document , removeArg[i]);
+    }  
+  }else{
+    deleteKey(document , removeArg);
+  }
+  function deleteKey (object , toRemoveKey) {
+    delete object[toRemoveKey];
+    return object;
+  }
+  return document; 
+}
+module.exports = { replaceKey , renameKey , removeKey };


### PR DESCRIPTION
now rename keys util method is being used in it's seperate file and not in the uploader method
rename keys is stable now as it is being used when we are creating the document in mongodb
when returning the document, populate middleware would suffice our requirement without having to rename the keys manually
renameKey method will now support multiple rename keys for one object, it will accept the array of keys or just a single key to be replaced